### PR TITLE
fix: entropy calculations

### DIFF
--- a/abd-clam/src/core/cluster/_cluster.rs
+++ b/abd-clam/src/core/cluster/_cluster.rs
@@ -627,7 +627,7 @@ impl<U: Number> Cluster<U> {
         criteria: &PartitionCriteria<U>,
         mut indices: Vec<usize>,
     ) -> (Self, Vec<usize>) {
-        if criteria.check(&self) {
+        if criteria.check(&self, &indices) {
             mt_log!(
                 Level::Debug,
                 "Partitioning cluster at depth {} with offset {} and cardinality {}.",

--- a/abd-clam/src/core/cluster/criteria.rs
+++ b/abd-clam/src/core/cluster/criteria.rs
@@ -13,7 +13,7 @@ use crate::Cluster;
 pub trait PartitionCriterion<U: Number>: Send + Sync {
     /// Check whether a `Cluster` meets the criterion for partitioning.
     // TODO: Figure out how to have this not leak `Cluster` or make `Cluster` public.
-    fn check(&self, c: &Cluster<U>) -> bool;
+    fn check(&self, c: &Cluster<U>, indices: &[usize]) -> bool;
 }
 
 /// A collection of criteria used to decide when to partition a `Cluster`.
@@ -82,12 +82,12 @@ impl<U: Number> PartitionCriteria<U> {
 }
 
 impl<U: Number> PartitionCriterion<U> for PartitionCriteria<U> {
-    fn check(&self, cluster: &Cluster<U>) -> bool {
+    fn check(&self, cluster: &Cluster<U>, indices: &[usize]) -> bool {
         !cluster.is_singleton()
             && if self.check_all {
-                self.criteria.iter().all(|c| c.check(cluster))
+                self.criteria.iter().all(|c| c.check(cluster, indices))
             } else {
-                self.criteria.iter().any(|c| c.check(cluster))
+                self.criteria.iter().any(|c| c.check(cluster, indices))
             }
     }
 }
@@ -97,7 +97,7 @@ impl<U: Number> PartitionCriterion<U> for PartitionCriteria<U> {
 pub struct MaxDepth(usize);
 
 impl<U: Number> PartitionCriterion<U> for MaxDepth {
-    fn check(&self, c: &Cluster<U>) -> bool {
+    fn check(&self, c: &Cluster<U>, _: &[usize]) -> bool {
         c.depth() < self.0
     }
 }
@@ -107,7 +107,7 @@ impl<U: Number> PartitionCriterion<U> for MaxDepth {
 pub struct MinCardinality(usize);
 
 impl<U: Number> PartitionCriterion<U> for MinCardinality {
-    fn check(&self, c: &Cluster<U>) -> bool {
+    fn check(&self, c: &Cluster<U>, _: &[usize]) -> bool {
         c.cardinality() > self.0
     }
 }

--- a/shell/src/utils.rs
+++ b/shell/src/utils.rs
@@ -29,8 +29,8 @@ pub struct MinShannonEntropy {
 ///
 /// `true` if the Shannon entropy of the cluster is greater than the threshold, `false` otherwise
 impl<U: Number> PartitionCriterion<U> for MinShannonEntropy {
-    fn check(&self, c: &Cluster<U>) -> bool {
-        let entropy = shannon_entropy_from_metadata(c, &self.data);
+    fn check(&self, _: &Cluster<U>, indices: &[usize]) -> bool {
+        let entropy = shannon_entropy_from_metadata(indices, &self.data);
         entropy > self.threshold
     }
 }
@@ -128,13 +128,13 @@ fn count_occurrences<T: Eq + Copy>(values: &[T]) -> Vec<(T, usize)> {
 ///
 #[allow(dead_code)]
 #[allow(clippy::cast_precision_loss)]
-pub fn shannon_entropy_from_metadata<U: Number>(
-    cluster: &Cluster<U>,
+pub fn shannon_entropy_from_metadata(
+    indices: &[usize],
     metadata: &VecDataset<Vec<f32>, f32, String>,
 ) -> f64 {
-    let cluster_metadata: Vec<_> = cluster
-        .indices()
-        .map(|i| metadata.metadata_of(i).unwrap())
+    let cluster_metadata: Vec<_> = indices
+        .iter()
+        .map(|&i| metadata.metadata_of(i).unwrap())
         .collect();
 
     // Put the metadata values and counts into an array of tuples


### PR DESCRIPTION
I have modified how cluster partition criteria work, to take the indices before dataset reordering. This should fix the silently wrong entropy values for the cluster labels